### PR TITLE
Retrieve and use frontmatter slug for generating links

### DIFF
--- a/src/methods/publishPost.ts
+++ b/src/methods/publishPost.ts
@@ -241,8 +241,16 @@ export const publishPost = async (
 
 		const [link, text] = p1.split("|");
 		const [id, slug] = link.split("#");
-		const url = `${BASE_URL}/${id}`;
-		const linkText = text || slug || link;
+
+		// Get frontmatter of the linked note
+		const linkedNote = app.metadataCache.getFirstLinkpathDest(id, noteFile.path);
+		const linkedNoteMeta = app.metadataCache.getFileCache(linkedNote)?.frontmatter;
+
+		// Get slug from frontmatter
+		const linkedNoteSlug = linkedNoteMeta?.slug;
+
+		const url = `${BASE_URL}/${linkedNoteSlug || slug || id}`;
+		const linkText = text || id || slug;
 		const linkHTML = `<a href="${url}">${linkText}</a>`;
 		return linkHTML;
 	}


### PR DESCRIPTION
- Updated the code to get the current file as the source for the getFirstLinkpathDest function
- Retrieved the frontmatter and slug of the linked note
- Used the slug from the frontmatter, if available, to generate the link URL
- Adjusted linkText for proper display when using slugs, e.g., [[Hello World#hello-world]]

This PR makes the following use-cases work:

```
Check out [[Hello World#hello-world|hello world]].

[[Another Post]]
```

Correctly generating links to the slug `hello-world` and `another-post` and using `hello world` and `Another Post` as text. In the first one, we're explicit about setting the slug because the linked note might not have a `slug` in its frontmatter, while in the second we can rely on the note having a `slug` in its frontmatter.

This enables easy publishing for vaults that don't use zettelkasten, and instead use regular human readable names for their notes.